### PR TITLE
simple "remaining time" display

### DIFF
--- a/USI_Converter/USI_Converter/ResourceConstraintEditorUpdaterAddon.cs
+++ b/USI_Converter/USI_Converter/ResourceConstraintEditorUpdaterAddon.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace USI
+{
+    [KSPAddon(KSPAddon.Startup.EditorAny, false)]
+    public class ResourceConstraintEditorUpdaterAddon : MonoBehaviour
+    {
+        private const string ModuleName = "USI_Converter";
+        private static short _updateCounter;
+        private static List<USI_ConverterModuleWrapper> _moduleList;
+        private static object _moduleListLock;
+
+        public void Update()
+        {
+            if (_updateCounter > 0)
+            {
+                _updateCounter--;
+                return;
+            }
+            _updateCounter = 15;
+            ProcessModuleList();
+        }
+
+        public void Awake()
+        {
+            _updateCounter = 0;
+            _moduleList = new List<USI_ConverterModuleWrapper>();
+            _moduleListLock = new object();
+            GameEvents.onPartAttach.Add(HandlePartAttach);
+            GameEvents.onPartRemove.Add(HandlePartRemove);
+        }
+
+        public void OnDestroy()
+        {
+            GameEvents.onPartAttach.Remove(HandlePartAttach);
+            GameEvents.onPartRemove.Remove(HandlePartRemove);
+        }
+
+        private static void ProcessModuleList()
+        {
+            lock (_moduleListLock)
+            {
+                var delList = new List<USI_ConverterModuleWrapper>();
+                foreach (var moduleWrapper in _moduleList)
+                {
+                    if (moduleWrapper.Module == null)
+                    {
+                        delList.Add(moduleWrapper);
+                    }
+                    else
+                    {
+                        moduleWrapper.Module.CollectResourceConstraintData();
+                    }
+                }
+                foreach (var moduleWrapper in delList)
+                {
+                    _moduleList.Remove(moduleWrapper);
+                }
+            }
+        }
+
+        private void HandlePartRemove(GameEvents.HostTargetAction<Part, Part> data)
+        {
+            var parts = GetPartList(data.target);
+            var modules = parts.Where(p => p.Modules.Contains(ModuleName)).Select(p => p.Modules[ModuleName] as USI_Converter).ToList();
+            lock (_moduleListLock)
+            {
+                foreach (var module in modules.Where(ListContainsModule))
+                {
+                    foreach (var moduleWrapper in _moduleList)
+                    {
+                        if (moduleWrapper.Module != null && moduleWrapper.Module.ID == module.ID)
+                        {
+                            _moduleList.Remove(moduleWrapper);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void HandlePartAttach(GameEvents.HostTargetAction<Part, Part> data)
+        {
+            var parts = GetPartList(data.host);
+            var modules = parts.Where(p => p.Modules.Contains(ModuleName)).Select(p => p.Modules[ModuleName] as USI_Converter).ToList();
+            foreach (var module in modules)
+            {
+                module.ID = Guid.NewGuid();
+            }
+            lock (_moduleListLock)
+            {
+                foreach (var module in modules.Where(module => !ListContainsModule(module)))
+                {
+                    _moduleList.Add(new USI_ConverterModuleWrapper(module));
+                }
+            }
+        }
+
+        private static bool ListContainsModule(USI_Converter module)
+        {
+            return _moduleList.Any(wrapper => wrapper.Module != null && wrapper.Module.ID == module.ID);
+        }
+
+        private static IEnumerable<Part> GetPartList(Part root)
+        {
+            var list = new List<Part>();
+            RecursePartList(list, root);
+            return list;
+        }
+
+        private static void RecursePartList(ICollection<Part> list, Part part)
+        {
+            list.Add(part);
+            foreach (var p in part.children)
+            {
+                RecursePartList(list, p);
+            }
+        }
+
+        private struct USI_ConverterModuleWrapper
+        {
+            internal USI_Converter Module { get; private set; }
+
+            internal USI_ConverterModuleWrapper(USI_Converter module)
+                : this()
+            {
+                Module = module;
+            }
+        }
+    }
+}

--- a/USI_Converter/USI_Converter/USI_Converter.cs
+++ b/USI_Converter/USI_Converter/USI_Converter.cs
@@ -53,8 +53,9 @@ namespace USI
 
         [KSPField] public bool requiresOxygenAtmo = false;
 
-        [KSPField(guiActive = true, guiActiveEditor = true, guiName = "Remaining")] public string RemainingTimeDisplay;
-        [KSPField(guiActive = true, guiActiveEditor = true, guiName = "Const.")] public string ConstraintDisplay;
+        [KSPField] public bool showRemainingTime = true;
+        [KSPField(guiActive = true, guiActiveEditor = true, guiName = "Remaining")] public string remainingTimeDisplay;
+        [KSPField(guiActive = true, guiActiveEditor = true, guiName = "Const.")] public string constraintDisplay;
         private const string NotAvailable = "n.a.";
         internal Guid ID;
         private short _constraintUpdateCounter = SlowConstraintInfoUpdate;
@@ -84,10 +85,17 @@ namespace USI
                 ID = Guid.NewGuid();
             }
 
+            if (!showRemainingTime)
+            {
+                var remTimeDisp = this.Fields["remainingTimeDisplay"];
+                var constDisp = this.Fields["constraintDisplay"];
+                remTimeDisp.guiActive = remTimeDisp.guiActiveEditor = constDisp.guiActive = constDisp.guiActiveEditor = false;
+            }
+
             UpdateEvents();
 
-            ConstraintDisplay = NotAvailable;
-            RemainingTimeDisplay = NotAvailable;
+            this.constraintDisplay = NotAvailable;
+            this.remainingTimeDisplay = NotAvailable;
         }
 
         public override void OnFixedUpdate()
@@ -371,6 +379,10 @@ namespace USI
 
         internal void CollectResourceConstraintData()
         {
+            if (!showRemainingTime)
+            {
+                return;
+            }
             if (HighLogic.LoadedSceneIsFlight)
             {
                 if (_constraintUpdateCounter > 0)
@@ -401,13 +413,13 @@ namespace USI
         {
             if (data == null)
             {
-                RemainingTimeDisplay = NotAvailable;
-                ConstraintDisplay = NotAvailable;
+                this.remainingTimeDisplay = NotAvailable;
+                this.constraintDisplay = NotAvailable;
                 return;
             }
             var info = data.GetConstraintInfo(ref _constraintUpdateCounter);
-            RemainingTimeDisplay = info[0];
-            ConstraintDisplay = info[1];
+            this.remainingTimeDisplay = info[0];
+            this.constraintDisplay = info[1];
         }
 
         private class ResourceConstraintData


### PR DESCRIPTION
Short video showing what this is supposed to add:
http://youtu.be/HUEESeWCfAY

Simplifications:
- Assumes full per-second-ratios without the dampening shenanigans the
  converter uses internally (thought I would get it more wrong trying to
  hook into than ignoring it)
- Since connectedResources is not available in the editor and simulating
  staging and fuel lines is a bit too much effort for this simple feature
  I only differentiate between NO_FLOW (only resources of current part)
  and everything else (all resource amounts in every part on the whole
  ship, using TAC-FB or so). I prefer this over not having any display in
  the editor, but that’s up to Rover.
- Code tries to find the limit which will be reached soonest. However,
  if multiple limits are reached at the same time it just selects one of
  those randomly.

One problem: if multiple converter modules are present it’s difficult to
see which constraint info belongs to which converter. No real idea how
to fix that though.

I tried to add/change as few as possible, but it ended up quite a lot.
Especially the add-on seems a bit unnecessary, but I haven’t found a
better way to update modules in editor yet. Feedback welcome!
Oh and I accidentally hit the reformat shortcut once and didn’t notice
it until I was nearly finished. RS happily reformatted some stuff, hope
it’s not too bad…

Rover: please feel free to add/remove/change whatever you want or even
reject the whole pr, hope some parts are useful for you anyway.
