### PR TITLE
Add manual pulse mode for Orion drive

### DIFF
--- a/USITools/USITools/EnginesAndTanks/USI_PulseDrive.cs
+++ b/USITools/USITools/EnginesAndTanks/USI_PulseDrive.cs
@@ -147,8 +147,7 @@ namespace USITools
 
         public override void OnFixedUpdate()
         {
-            // Don't surprise the user with a manual pulse lurking
-            // eg because the engine was switched off
+			// Don't surprise the user with a manual pulse lurking (eg because the engine was set to use a missing fuel)
             pulseNow = pulseASAP; pulseASAP = false;
 
             if (!HighLogic.LoadedSceneIsFlight)


### PR DESCRIPTION
Here's the same patch (modulo comments) relative to your DEVELOP branch, as requested. Compiled and tested in KSP 1.0.5 today, and it seems to work.
