### PR TITLE
Return part count checks for adding category

### DIFF
--- a/USITools/USITools/PartCatalog.cs
+++ b/USITools/USITools/PartCatalog.cs
@@ -34,7 +34,10 @@ namespace USITools
             }
 
             print("KolonyFilter Count: " + kolonyParts.Count);
-            GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+            if (kolonyParts.Count > 0)
+            {
+                GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+            }
         }
 
         private static bool EditorItemsFilter(AvailablePart avPart)
@@ -75,8 +78,10 @@ namespace USITools
 
             print("FreightFilter Count: " + kolonyParts.Count);
 
-            //if (kolonyParts.Count > 0)
-            GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+            if (kolonyParts.Count > 0)
+            {
+                GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+            }
         }
 
         private static bool EditorItemsFilter(AvailablePart avPart)
@@ -121,8 +126,10 @@ namespace USITools
 
             print("KolonyLiteFilter Count: " + kolonyParts.Count);
 
-            //if (kolonyParts.Count > 0)
-            GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+            if (kolonyParts.Count > 0)
+            {
+                GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+            }
         }
 
         private static bool EditorItemsFilter(AvailablePart avPart)
@@ -162,10 +169,10 @@ namespace USITools
             }
 
             print("RoverFilter Count: " + kolonyParts.Count);
-            //if (kolonyParts.Count > 0)
-            //{
-            GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
-            //}
+            if (kolonyParts.Count > 0)
+            {
+                GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+            }
         }
 
         private static bool EditorItemsFilter(AvailablePart avPart)


### PR DESCRIPTION
Part count checks disappeared after KSP 1.1 update and empty categories are being added into part filters.
