### PR TITLE
Fix AVC version check URL

### DIFF
--- a/FOR_RELEASE/GameData/000_USITools/USITools.version
+++ b/FOR_RELEASE/GameData/000_USITools/USITools.version
@@ -1,6 +1,6 @@
 {
      "NAME":"USI Tools",
-	 "URL":"https://raw.githubusercontent.com/BobPalmer/UmbraSpaceIndustries/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/USICore.version",
+	 "URL":"https://raw.githubusercontent.com/BobPalmer/UmbraSpaceIndustries/master/FOR_RELEASE/GameData/000_USITools/USITools.version",
 	 "DOWNLOAD":"https://github.com/BobPalmer/UmbraSpaceIndustries/releases",
      "GITHUB":{
          "USERNAME":"BobPalmer",


### PR DESCRIPTION
In USITools.version, the URL where version checkers are supposed to look for current version data was pointing to a file that no longer exists on the `master` branch. I updated that URL to properly point to the repository's copy of USITools.version so KSP-AVC and compatible tools can tell when USITools has been updated.
