### PR TITLE
Allow power distribution with nearby engineers

### DIFF
--- a/USITools/USITools/Logistics/LogisticsTools.cs
+++ b/USITools/USITools/Logistics/LogisticsTools.cs
@@ -67,5 +67,11 @@ namespace KolonyTools
                 return (p.vessel.GetVesselCrew().Any(c => c.experienceTrait.TypeName == skill));
             }
         }
+
+        public static bool NearbyCrew(Vessel v, float range, String skill)
+        {
+            List<Vessel> nearby = GetNearbyVessels(range, true, v, true);
+            return nearby.Any(near=>near.GetVesselCrew().Any(c=>c.experienceTrait.TypeName==skill));
+        }
     }
 }

--- a/USITools/USITools/Logistics/ModulePowerDistributor.cs
+++ b/USITools/USITools/Logistics/ModulePowerDistributor.cs
@@ -1,3 +1,5 @@
+using USITools.Logistics;
+
 namespace KolonyTools
 {
     [KSPModule("Power Distributor")]
@@ -13,7 +15,7 @@ namespace KolonyTools
         {
             get
             {
-                return this.part != null && LogisticsTools.HasCrew(this.part, "Engineer");
+                return this.part != null && LogisticsTools.NearbyCrew(this.vessel, LogisticsSetup.Instance.Config.ScavangeRange, "Engineer");
             }
         }
 


### PR DESCRIPTION
I believe that for power distribution to work the engineer should only have to be in the general vicinity of the power producer, close enough to check up on it, plug in cables etc.

For gameplay reasons I would prefer my Kerbal not to have to live on top of the reactor :)
