### PR TITLE
Allow mechanics to perfom EVA maintenance

### DIFF
--- a/USITools/USITools/Logistics/USI_ModuleFieldRepair.cs
+++ b/USITools/USITools/Logistics/USI_ModuleFieldRepair.cs
@@ -22,9 +22,9 @@ namespace USITools
         public void PerformMaintenance()
         {
             var kerbal = FlightGlobals.ActiveVessel.rootPart.protoModuleCrew[0];
-            if (kerbal.experienceTrait.Title != "Engineer")
+            if (!kerbal.HasEffect("RepairSkill"))
             {
-                ScreenMessages.PostScreenMessage("Only Engineers can perform EVA Maintenance!", 5f,
+                ScreenMessages.PostScreenMessage("Only Kerbals with repair skills (engineers, mechanics) can perform EVA Maintenance!", 5f,
                     ScreenMessageStyle.UPPER_CENTER);
                 return;
             }


### PR DESCRIPTION
Currently engineers are overpowered, and mechanics almost useless.
If you are planning a rebalance of the whole classes, consider this as a temporary fix while waiting for that to come out.