### PR TITLE
Fix exception when using manual maintenance in some cases

### DIFF
--- a/USITools/USITools/Logistics/USI_ModuleFieldRepair.cs
+++ b/USITools/USITools/Logistics/USI_ModuleFieldRepair.cs
@@ -68,6 +68,10 @@ namespace USITools
 
         private void PushResources(string resourceName)
         {
+            if (!part.Resources.Contains(resourceName))
+            {
+                return;
+            }
             var brokRes = part.Resources[resourceName];
             //Put remaining parts in warehouses
             var wh = LogisticsTools.GetRegionalWarehouses(vessel, "USI_ModuleCleaningBin");


### PR DESCRIPTION
Issue #1163
PushResources is "DepletedFuel,Recyclables" but sometimes the target part does not contain any DepletedFuel.