### PR TITLE
Fix infinite loop with "prev loadout" when USILS is not installed

### DIFF
--- a/USITools/USITools/ModuleSwappableConverter.cs
+++ b/USITools/USITools/ModuleSwappableConverter.cs
@@ -56,6 +56,9 @@ namespace USITools
         [KSPEvent(active = true, guiActiveUnfocused = true, externalToEVAOnly = true, guiName = "B1:  Prev. Loadout", unfocusedRange = 10f)]
         public void PrevSetup()
         {
+            if (Loadouts.Count < 2)
+                return;
+            
             displayLoadout--;
             if (displayLoadout < 0)
             {


### PR DESCRIPTION
Remark: the last commit "A little code cleanup" is incomplete: ExplorerSkill.cs has not been moved with the rest, and for all files that have been moved, USITools.csproj still refers to the old location, so it does not compile (I could not commit that fix, as I must apply other modifications to the project file).