### PR TITLE
Allow incremental payment of inflatables deployment cost

### DIFF
--- a/USITools/USITools/ConverterPart.cs
+++ b/USITools/USITools/ConverterPart.cs
@@ -5,8 +5,8 @@ namespace USITools
     public class ConverterPart
     {
         public Part HostPart { get; set; }
-        public List<IEfficiencyBonusConsumer> Converters { get; }
-        public List<ModuleSwappableConverter> SwapBays { get; }
+        public List<IEfficiencyBonusConsumer> Converters { get; set; }
+        public List<ModuleSwappableConverter> SwapBays { get; set; }
         public ConverterPart(Part p)
         {
             Converters = new List<IEfficiencyBonusConsumer>();


### PR DESCRIPTION
+ small fix of EC deployment cost (was counted twice for the current vessel's parts, then not consumed if actually not enough).

I used a few linq and foreach, but that's only in code triggered by user interaction, nothing automatic.