### PR TITLE
Re-Write Weight Distribution Function

### DIFF
--- a/USITools/USITools/Logistics/ModuleWeightDistributableCargo.cs
+++ b/USITools/USITools/Logistics/ModuleWeightDistributableCargo.cs
@@ -6,9 +6,8 @@ namespace USITools
         {
             if (part.parent != null && part.children.Count == 0)
                 return;
-            
-            if (part.physicalSignificance == Part.PhysicalSignificance.NONE)
-                part.physicalSignificance = Part.PhysicalSignificance.FULL;
+
+            part.CoMOffset = Vector3d.zero;
         }
     }
 }

--- a/USITools/USITools/Logistics/ModuleWeightDistributor.cs
+++ b/USITools/USITools/Logistics/ModuleWeightDistributor.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using KSP;
+using UnityEngine;
 
 namespace USITools
 {
@@ -76,9 +79,21 @@ namespace USITools
                     disablePhysics = false;
 
                 if (disablePhysics)
-                    p.physicalSignificance = Part.PhysicalSignificance.NONE;
+                {
+                    Transform childtransform = p.partTransform;
+                    Transform transform = part.partTransform;
+
+                    Vector3d worldPartPosition;
+                    Vector3d localPartPosition;
+                    Vector3d childlocalPosition;
+
+                    localPartPosition = part.CoMOffset;
+                    worldPartPosition = transform.TransformPoint(localPartPosition);
+                    childlocalPosition = childtransform.InverseTransformPoint(worldPartPosition);
+                    p.CoMOffset = childlocalPosition;
+                }
                 else
-                    p.physicalSignificance = Part.PhysicalSignificance.FULL;
+                    p.CoMOffset = Vector3d.zero;
             }
         }
     }


### PR DESCRIPTION
Remove all physicalSignificance references, modules now move the CofM of child parts to match the CofM of Weight Distributor.