### PR TITLE
Fix for airbags module

### DIFF
--- a/USITools/USITools/Airbags/ModuleAirbag.cs
+++ b/USITools/USITools/Airbags/ModuleAirbag.cs
@@ -87,11 +87,11 @@ namespace AirbagTools
 
             try
             {
-                if (part.checkLanded())
+                if (part.checkLanded() && isDeployed)
                 {
                     Dampen();
                 }
-                if (part.Landed)
+                if (part.Landed && isDeployed)
                 {
                     Dampen();
                 }


### PR DESCRIPTION
Check if airbags are in deployed state before calling Dampen().
This addresses the bug where horizontally moving craft get their speed reset to 0 after reaching 50m/s with deflated airbags.