### PR TITLE
Add agent title for 'Umbra Space Industries'

### DIFF
--- a/FOR_RELEASE/GameData/000_USITools/Agency/USIAgency.cfg
+++ b/FOR_RELEASE/GameData/000_USITools/Agency/USIAgency.cfg
@@ -1,6 +1,7 @@
 AGENT
 {
     name = Umbra Space Industries
+	title = Umbra Space Industries
 
     description = A world leader in corrugated paper products, Umbra Space Industries is now applying their formidable boxing and packaging skills into a a series of products for colonization, exploration, and resource exploitation!
 


### PR DESCRIPTION
KSP complained about that into log.

It also fix the following:
- Missing agent from mission UI
- Missing agent filtering from SPH/VAB (that being said, many USI parts are not from "Umbra Space Industries", it only fix some of them)