### PR TITLE
Add backward-compatibility patch for converters relevant to life support

### DIFF
--- a/FOR_RELEASE/GameData/000_USITools/ConvertersBackwardCompatibility.cfg
+++ b/FOR_RELEASE/GameData/000_USITools/ConvertersBackwardCompatibility.cfg
@@ -1,0 +1,233 @@
+// This patch attempts to upgrade parts that rely on certain obsolete USI
+// PartModules, to use the new USI_Converter system instead.  It focuses on
+// modules that are directly needed for life support (habs, recyclers,
+// greenhouses), and doesn't attempt to handle things like resource harvesting.
+// Though it works OK for many parts, there's no guarantee that it correcly
+// handles all of them, and it is not intended as a long-term solution;
+// maintainers of mods that integrate with USI should still update their own
+// integration patches.  This patch is just meant to get most parts into at
+// least a usable state until then.
+
+// ModuleLifeSupport no longer exists and is safe to just remove.
+@PART[*]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	!MODULE[ModuleLifeSupport],* { }
+}
+
+// Find parts that'll need updating, and mark them for processing.
+@PART[*]:HAS[@MODULE[ModuleHabitation],!MODULE[USI_SwapController]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	usiConvertersBackwardCompatApplied = true
+}
+@PART[*]:HAS[@MODULE[ModuleLifeSupportRecycler],!MODULE[USI_SwapController]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	usiConvertersBackwardCompatApplied = true
+}
+@PART[*]:HAS[@MODULE[ModuleResourceConverter_USI],!MODULE[USI_SwapController]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	usiConvertersBackwardCompatApplied = true
+}
+
+// If the part doesn't have a swappable converter, its resource converters (if
+// any) are standalone, so update them to the new type of standalone converters.
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],!MODULE[ModuleSwappableConverter]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	@MODULE[ModuleResourceConverter_USI],*
+	{
+		@name = USI_Converter
+		IsStandaloneConverter = true
+	}
+}
+
+// Anything else is either a non-standalone converter, or a type that doesn't
+// support standalone (e.g. hab and recyclers).  Change these to swap options.
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	@MODULE[ModuleHabitation],*
+	{
+		@name = USILS_HabitationSwapOption
+	}
+
+	@MODULE[ModuleLifeSupportRecycler],*
+	{
+		@name = USILS_LifeSupportRecyclerSwapOption
+	}
+
+	@MODULE[ModuleResourceConverter_USI],*
+	{
+		@name = USI_ConverterSwapOption
+	}
+}
+
+// If there are any swap options, add a controller to handle them.
+// (This needs to precede the converters and swappable bays.)
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USILS_HabitationSwapOption]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	usiConvertersBackwardCompatNeedsSwapper = true
+}
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USILS_LifeSupportRecyclerSwapOption]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	usiConvertersBackwardCompatNeedsSwapper = true
+}
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_ConverterSwapOption]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	usiConvertersBackwardCompatNeedsSwapper = true
+}
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],#usiConvertersBackwardCompatNeedsSwapper[true]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	MODULE
+	{
+		name = USI_SwapController
+	}
+
+	// This variable is no longer needed.
+	!usiConvertersBackwardCompatNeedsSwapper = deleted
+}
+
+// A sawp controller needs at least one swappable bay for the swap options to
+// appear in.  This may not be present, e.g. in the case of a hab or recycler
+// module that didn't need a swapper in the past.  Add an old-style
+// ModuleSwappableConverter if necessary; it'll be converted to the new format
+// later.
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_SwapController],!MODULE[ModuleSwappableConverter]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	MODULE
+	{
+		name = ModuleSwappableConverter
+		bayName = B1
+	}
+}
+
+// Convert each old-style ModuleSwappableConverter to its new-style replacement,
+// a USI_SwappableBay and USI_Converter pair.
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[ModuleSwappableConverter]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	usiConvertersBackwardCompatNextModuleIndex = 0
+}
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[ModuleSwappableConverter]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	// Add the new converter module.
+	MODULE
+	{
+		name = USI_Converter
+	}
+
+	// Change the old converter to a bay that just handles loadout
+	// configuration of the new one.
+	@MODULE[ModuleSwappableConverter],0
+	{
+		@name = USI_SwappableBay
+		!typeName = deleted
+		moduleIndex = #$/usiConvertersBackwardCompatNextModuleIndex$
+
+		// Old swappable converters used bay names "B1", "B2", etc.
+		// New naming convention is "Bay 1", "Bay 2", etc.
+		@bayName ^= :B(\d):Bay $1:
+
+		// Increment index for the next converter
+		*/usiConvertersBackwardCompatNextModuleIndex += 1
+	}
+
+	// Repeat until the part has no ModuleSwappableConverter remaining.
+	MM_PATCH_LOOP {}
+}
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],#nextModuleIndex]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	// This was just used to assign sequential moduleIndex values to the
+	// swappable bays, so it's no longer needed.
+	!usiConvertersBackwardCompatNextModuleIndex = deleted
+}
+
+// Transfer specialist configuration from the swap options (which used to be
+// actual converters) to the new converters controlled by the swapper.
+// This gets a little weird because the number of swap options can differ from
+// the number of bays and converters, so there's no one-to-one relationship.
+// Generally the values are the same for all swap potions, so just take them
+// from the first one.
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_ConverterSwapOption]:HAS[#SpecialistEfficiencyFactor]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	@MODULE[USI_Converter]:HAS[~IsStandaloneConverter[true]]
+	{
+		SpecialistEfficiencyFactor = #$/MODULE[USI_ConverterSwapOption]:HAS[#SpecialistEfficiencyFactor]/SpecialistEfficiencyFactor$
+	}
+}
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_ConverterSwapOption]:HAS[#SpecialistBonusBase]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	@MODULE[USI_Converter]:HAS[~IsStandaloneConverter[true]]
+	{
+		SpecialistBonusBase = #$/MODULE[USI_ConverterSwapOption]:HAS[#SpecialistBonusBase]/SpecialistBonusBase$
+	}
+}
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_ConverterSwapOption]:HAS[#UseSpecialistBonus]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	@MODULE[USI_Converter]:HAS[IsStandaloneConverter[true]]
+	{
+		UseSpecialistBonus = #$/MODULE[USI_ConverterSwapOption]:HAS[#UseSpecialistBonus]/UseSpecialistBonus$
+	}
+}
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_ConverterSwapOption]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	@MODULE[USI_ConverterSwapOption],*
+	{
+		!SpecialistEfficiencyFactor = deleted
+		!SpecialistBonusBase = deleted
+		!UseSpecialistBonus = deleted
+	}
+}
+
+// Previously, swap costs were configured separately on each
+// ModuleSwappableConverter.  Now they're part of the USI_SwapController,
+// shared between all USI_Converter.
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_SwappableBay]:HAS[#ResourceCosts]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	// Copy the ResourceCosts from the first USI_SwappableBay
+	// (formerly the ModuleSwappableConverter).
+	@MODULE[USI_SwapController]
+	{
+		ResourceCosts = #$/MODULE[USI_SwappableBay]:HAS[#ResourceCosts]/ResourceCosts$
+	}
+
+	// Delete the ResourceCosts from the old location(s) now that it's
+	// been copied to the new.
+	@MODULE[USI_SwappableBay],*
+	{
+		!ResourceCosts = deleted
+	}
+}
+
+// Swappable converters must be defined *before* standalone ones, or they don't
+// work correctly.  If both types are present, move the standalone converter(s)
+// to the end.
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_Converter]:HAS[#IsStandaloneConverter[true]],@MODULE[USI_Converter]:HAS[~IsStandaloneConverter[true]]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	// First make copies...
+	$MODULE[USI_Converter]:HAS[#IsStandaloneConverter[true]]
+	{
+		usiConvertersBackwardCompatConverterCopied = true
+	}
+
+	// ...then delete the originals...
+	!MODULE[USI_Converter]:HAS[#IsStandaloneConverter[true],~usiConvertersBackwardCompatConverterCopied[true]] { }
+
+	// ...then remove the copy markers.
+	@MODULE[USI_Converter]:HAS[#IsStandaloneConverter[true],#usiConvertersBackwardCompatConverterCopied[true]]
+	{
+		!usiConvertersBackwardCompatConverterCopied = deleted
+	}
+}
+
+// Lastly, we've removed all the obsolete modules, but let's add a bogus one
+// that says that the part is relying on backward compatibility, so it shows up
+// in the log.  This patch is meant only as an interim measure for parts that
+// haven't yet been updated by their maintainers, so it should complain a bit
+// to help remind people that that's needed.
+@PART[*]:HAS[#usiConvertersBackwardCompatApplied[true]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
+{
+	MODULE
+	{
+		name = ThisPartUsesObsoleteUsiModules
+	}
+
+	// All done!
+	!usiConvertersBackwardCompatApplied = deleted
+}

--- a/FOR_RELEASE/GameData/000_USITools/ConvertersBackwardCompatibility.cfg
+++ b/FOR_RELEASE/GameData/000_USITools/ConvertersBackwardCompatibility.cfg
@@ -142,7 +142,7 @@
 // actual converters) to the new converters controlled by the swapper.
 // This gets a little weird because the number of swap options can differ from
 // the number of bays and converters, so there's no one-to-one relationship.
-// Generally the values are the same for all swap potions, so just take them
+// Generally the values are the same for all swap options, so just take them
 // from the first one.
 @PART[*]:HAS[#usiConvertersBackwardCompatApplied[true],@MODULE[USI_ConverterSwapOption]:HAS[#SpecialistEfficiencyFactor]]:FOR[ZZZZ_USI_CONVERTERS_BACKWARD_COMPAT]
 {


### PR DESCRIPTION
This patch attempts to upgrade parts that rely on certain obsolete USI PartModules, to use the new USI_Converter system instead.  It focuses on modules that are directly needed for life support (habs, recyclers, greenhouses), and doesn't attempt to handle things like resource harvesting.  Though it works OK for many parts, there's no guarantee that it correctly handles all of them, and it is not intended as a long-term solution; maintainers of mods that integrate with USI should still update their own integration patches.  This patch is just meant to get most parts into at least a usable state until then.