### PR TITLE
Update module USI_ModuleFieldRepair patch

### DIFF
--- a/FOR_RELEASE/GameData/000_USITools/Logistics.cfg
+++ b/FOR_RELEASE/GameData/000_USITools/Logistics.cfg
@@ -18,7 +18,31 @@ RESOURCE_DEFINITION  //Hidden resource used to manage mass
     volume = 1
 }
 
-@PART[*]:HAS[!MODULE[USI_ModuleFieldRepair],@RESOURCE[Machinery|EnrichedUranium|DepletedFuel|Recyclables]]:FOR[USITools]
+@PART[*]:HAS[!MODULE[USI_ModuleFieldRepair],@RESOURCE[Machinery]]:FOR[USITools]
+{
+    MODULE
+    {
+        name = USI_ModuleFieldRepair
+    }
+}
+
+@PART[*]:HAS[!MODULE[USI_ModuleFieldRepair],@RESOURCE[EnrichedUranium]]:FOR[USITools]
+{
+    MODULE
+    {
+        name = USI_ModuleFieldRepair
+    }
+}
+
+@PART[*]:HAS[!MODULE[USI_ModuleFieldRepair],@RESOURCE[DepletedFuel]]:FOR[USITools]
+{
+    MODULE
+    {
+        name = USI_ModuleFieldRepair
+    }
+}
+
+@PART[*]:HAS[!MODULE[USI_ModuleFieldRepair],@RESOURCE[Recyclables]]:FOR[USITools]
 {
     MODULE
     {


### PR DESCRIPTION
I found that module USI_ModuleFieldRepair still isn't applied, so I brought this to MM thread. The reason for it is, that you can't have OR syntax in HAS block. I splitted the MM patch and it worked as intended.