### PR TITLE
Update version file URLs to current repo owner

### DIFF
--- a/FOR_RELEASE/GameData/000_USITools/USITools.version
+++ b/FOR_RELEASE/GameData/000_USITools/USITools.version
@@ -1,10 +1,10 @@
 {
      "NAME":"USI Tools",
-	 "URL":"https://raw.githubusercontent.com/BobPalmer/UmbraSpaceIndustries/master/FOR_RELEASE/GameData/000_USITools/USITools.version",
-	 "DOWNLOAD":"https://github.com/BobPalmer/UmbraSpaceIndustries/releases",
+	 "URL":"https://raw.githubusercontent.com/UmbraSpaceIndustries/USITools/master/FOR_RELEASE/GameData/000_USITools/USITools.version",
+	 "DOWNLOAD":"https://github.com/UmbraSpaceIndustries/USITools/releases",
      "GITHUB":{
-         "USERNAME":"BobPalmer",
-         "REPOSITORY":"UmbraSpaceIndustries",
+         "USERNAME":"UmbraSpaceIndustries",
+         "REPOSITORY":"USITools",
          "ALLOW_PRE_RELEASE":false
      },
      "VERSION":{


### PR DESCRIPTION
Hi @BobPalmer,

The URLs in this mod's version file are slightly out of date, they still have the previous repo owner. GitHub helpfully silently redirects them, so they still work, but this can sometimes trrigger GitHub's server-side rate limiting behavior.

Now they're updated to the latest correct values.