### PR TITLE
AssemblyInfo.cs Updates

### DIFF
--- a/Source/USITools/Properties/AssemblyInfo.cs
+++ b/Source/USITools/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: KSPAssemblyDependency("USIToolsUI", 1, 0)]

--- a/Source/USIToolsUI/Properties/AssemblyInfo.cs
+++ b/Source/USIToolsUI/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: KSPAssembly("USIToolsUI",1,0)]


### PR DESCRIPTION
Reference: https://github.com/jrbudda/KerbalEngineer/commit/9bd31dcb47f8d6ee2c90b0aa80e5dae267069e7c
This prevents an issue that started appearing in KSP 1.8 ("[ERROR] ADDON BINDER: Cannot resolve assembly").
Doesn't really do anything for USI's functionality, but should make sure everything that loads after is alright.